### PR TITLE
bioRxiv won't take preprints, so migrate to eScholarship

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The [latest version](https://github.com/MobleyLab/benchmarksets/blob/master/pape
 
 ## The paper
 
-The most up-to-date version of this perpetual review is always available [here](https://github.com/MobleyLab/benchmarksets/blob/master/paper/benchmarkset.pdf). Additionally, this repository provides the authoritative source for all versions of this paper. Selected versions of the paper are also archived preprints on [bioRxiv](http://biorxiv.org/content/early/2016/09/11/074625). An early version of this work was published in [Annual Review of Biophysics 46:531-558 (2017)](https://doi.org/10.1146/annurev-biophys-070816-033654). The Annual Reviews version will likely go out of date, though we are endeavoring to keep the bioRxiv version current.
+The most up-to-date version of this perpetual review is always available [here](https://github.com/MobleyLab/benchmarksets/blob/master/paper/benchmarkset.pdf). Additionally, this repository provides the authoritative source for all versions of this paper. Released versions of the paper are also archived as preprints on[eScholarship](http://escholarship.org/uc/item/9p37m6bq). An early version of this work was published in [Annual Review of Biophysics 46:531-558 (2017)](https://doi.org/10.1146/annurev-biophys-070816-033654). The Annual Reviews version will likely go out of date, though we are endeavoring to keep the eScholarship version current.
 
 Source files for the paper are deposited here on this GitHub repository, as detailed below, and comments/suggestions, etc. are welcome via the issue tracker (https://github.com/MobleyLab/benchmarksets/issues).
 
@@ -82,7 +82,7 @@ Please note that GitHub's automatic "contributors" list does not provide a full 
 
 ## Versions
 - [AR](https://doi.org/10.1146/annurev-biophys-070816-033654): Annual Review in Biophysics 46:531-558 (2017). This version split from this repo around the time of the 1.0 release below.
-- [v1.0](https://github.com/MobleyLab/benchmarksets/releases/tag/v1.0): As posted to bioRxiv 
+- [v1.0](https://github.com/MobleyLab/benchmarksets/releases/tag/v1.0): As posted to [bioRxiv](http://biorxiv.org/content/early/2016/09/11/074625) 
 - v1.0.1 ([10.5281/zenodo.155330](https://doi.org/10.5281/zenodo.15533)): Incorporating improved tables and typo fixes from D. Slochower; also, versions now have unique DOIs via Zenodo.
 - v1.0.4 ([10.5281/zenodo.167349](http://doi.org/10.5281/zenodo.167349)): Maintenance version fixing an incorrect PDB code and adding a new reference and some new links.
 - v1.1 ([10.5281/zenodo.197428](http://doi.org/10.5281/zenodo.197428)): Adds significant additional discussion on potential future benchmark sets, needs for workflow science, etc. See release notes for more details. Versions also now include the date and version number within the PDF.
@@ -92,8 +92,10 @@ Please note that GitHub's automatic "contributors" list does not provide a full 
 
 ## Changes not yet in a release
 - Updates to README.md to reflect publication of Annual Reviews version
+- Updates to README.md to reflect availability on eScholarship
+- Update to paper to reflect migration to eScholarship rather than bioRxiv
 
 ## Manifest
 
-* paper: Provides LaTeX source files for the manuscript as submitted to bioRxiv (reformatted from the version submitted to Ann. Rev. and with 2D structures added to the tables); images, etc. are also available in sub-directories, as is the supporting information.
+* paper: Provides LaTeX source files and final PDF for the current version of the manuscript (reformatted from the version submitted to Ann. Rev. and with 2D structures added to the tables); images, etc. are also available in sub-directories, as is the supporting information.
 * input_files: Host-guest structures and simulation input files for the host-guest benchmark sets proposed in the paper (provided by Jian Yin from the Gilson lab)

--- a/paper/benchmarkset.tex
+++ b/paper/benchmarkset.tex
@@ -915,7 +915,7 @@ We also expect that there may be community interest in test systems specifically
 
 In order to provide for updates of this material as new benchmark systems are defined, and to enable community input into the process of choosing them, we have made the LaTeX source for this article on GitHub at \url{http://www.github.com/mobleylab/benchmarksets}, with each version having a permanent DOI assigned by Zenodo. 
 We encourage use of the GitHub issue tracker for discussion, comments, and proposed updates. 
-We plan to incorporate new material via GitHub as one would for a coding project, then make it available via a preprint server, likely bioRxiv.
+We are incorporating new material via GitHub as one would for a coding project, and then making releases available both on GitHub and in more permanent form at eScholarship at \url{http://escholarship.org/uc/item/9p37m6bq}.
 Given substantial changes to this initial version of the paper, it may ultimately be appropriate to make it available as a ``perpetual review''~\cite{mobley_proposal_2015} via another forum allowing versioned updates of publications. 
 
 Ideally, we might also update this work in the future with results from ``standard'' calculations on the benchmark systems discussed here, along with links to code to allow reproduction of those calculations.


### PR DESCRIPTION
Now that the paper is out in Ann. Rev., bioRxiv will no longer take updates of the "preprint" we have there. I've argued that this is a special case since it's not the same work as in Ann. Rev. (since we're extending it) but they are unable to make an exception in this case.

So, I've migrated away from bioRxiv to the UC's epublication site eScholarship, and deposited all versions of the work here: http://escholarship.org/uc/item/9p37m6bq

This PR incorporates updates to the README.md and manuscript to reflect use of eScholarship rather than bioRxiv.